### PR TITLE
Check manual url for 404 error

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -10,5 +10,5 @@ services:
         value: production
       - key: PORT
         value: 10000
-    healthCheckPath: /health
+    healthCheckPath: /api/health
 


### PR DESCRIPTION
Correct `healthCheckPath` in `render.yaml` to fix deployment issues causing 404s.

The `healthCheckPath` in `render.yaml` was incorrectly set to `/health` instead of the actual health endpoint `/api/health`. This misconfiguration prevented the Render.com deployment from starting correctly, leading to 404 errors for various routes on the deployed server.

---
<a href="https://cursor.com/background-agent?bcId=bc-04560992-e3cd-458d-beee-7bf3c1e20cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04560992-e3cd-458d-beee-7bf3c1e20cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Bug Fixes:
- Correct healthCheckPath in render.yaml from /health to /api/health to ensure the Render.com deployment starts successfully