### PR TITLE
Add facilitate to navbar on meeting creation

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { Menu, X, Plus, UserPlus, MessageSquare, QrCode } from 'lucide-react'
+import { Menu, X, Plus, UserPlus, MessageSquare, QrCode, Settings } from 'lucide-react'
 import ThemeToggle from '../ui/ThemeToggle'
 import { useMouseFollow } from '@/hooks/use-mouse-follow'
+import { useMeetingCreator } from '@/hooks/useMeetingCreator'
 
 interface AppLayoutProps {
   children: ReactNode
@@ -10,6 +11,7 @@ interface AppLayoutProps {
 
 function AppLayout({ children }: AppLayoutProps) {
   const location = useLocation()
+  const { creatorInfo, isCreator } = useMeetingCreator()
   const isActive = (path: string) => {
     if (path === '/') {
       return location.pathname === '/'
@@ -159,6 +161,19 @@ function AppLayout({ children }: AppLayoutProps) {
                 )
               })()}
             </nav>
+            
+            {/* Facilitate Button - Only show if user is a meeting creator */}
+            {isCreator && creatorInfo && (
+              <Link
+                to={`/facilitate/${creatorInfo.meetingCode}`}
+                className="hidden md:flex items-center px-4 py-2 bg-accent text-white rounded-lg font-semibold hover:bg-accent-hover transition-colors"
+                title={`Facilitate: ${creatorInfo.meetingTitle}`}
+              >
+                <Settings className="w-4 h-4 mr-2" />
+                Facilitate
+              </Link>
+            )}
+            
             <ThemeToggle />
             <button
               className="md:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-zinc-800"
@@ -227,6 +242,17 @@ function AppLayout({ children }: AppLayoutProps) {
                   <QrCode className="w-3 h-3 mr-2" />
                   Join Meeting
                 </Link>
+                {/* Facilitate Button for Mobile */}
+                {isCreator && creatorInfo && (
+                  <Link
+                    to={`/facilitate/${creatorInfo.meetingCode}`}
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="h-8 flex items-center px-4 rounded-lg text-sm font-medium bg-accent/20 text-accent hover:bg-accent/30"
+                  >
+                    <Settings className="w-3 h-3 mr-2" />
+                    Facilitate
+                  </Link>
+                )}
               </div>
             </div>
           </nav>

--- a/src/hooks/useMeetingCreator.ts
+++ b/src/hooks/useMeetingCreator.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface MeetingCreatorInfo {
+  meetingCode: string;
+  facilitatorName: string;
+  meetingTitle: string;
+}
+
+const STORAGE_KEY = 'meeting_creator_info';
+
+export function useMeetingCreator() {
+  const [creatorInfo, setCreatorInfo] = useState<MeetingCreatorInfo | null>(null);
+
+  // Load creator info from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        setCreatorInfo(parsed);
+      }
+    } catch (error) {
+      console.error('Error loading meeting creator info:', error);
+    }
+  }, []);
+
+  // Save creator info to localStorage
+  const setCreator = useCallback((info: MeetingCreatorInfo) => {
+    setCreatorInfo(info);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(info));
+    } catch (error) {
+      console.error('Error saving meeting creator info:', error);
+    }
+  }, []);
+
+  // Clear creator info
+  const clearCreator = useCallback(() => {
+    setCreatorInfo(null);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.error('Error clearing meeting creator info:', error);
+    }
+  }, []);
+
+  // Check if current user is creator of a specific meeting
+  const isCreatorOf = useCallback((meetingCode: string) => {
+    return creatorInfo?.meetingCode === meetingCode;
+  }, [creatorInfo]);
+
+  return {
+    creatorInfo,
+    setCreator,
+    clearCreator,
+    isCreatorOf,
+    isCreator: !!creatorInfo
+  };
+}

--- a/src/pages/CreateMeeting.tsx
+++ b/src/pages/CreateMeeting.tsx
@@ -6,6 +6,7 @@ import apiService from '../services/api'
 import { toast } from '@/hooks/use-toast'
 import { playBeep } from '../utils/sound.js'
 import Confetti from '../components/ui/Confetti.jsx'
+import { useMeetingCreator } from '../hooks/useMeetingCreator'
 
 interface MeetingData {
   name: string
@@ -17,6 +18,7 @@ interface MeetingData {
 
 function CreateMeeting(): JSX.Element {
   const navigate = useNavigate()
+  const { setCreator } = useMeetingCreator()
   const notify = (type: 'success' | 'error' | 'info', title: string, description?: string) => {
     toast({ title, description })
   }
@@ -53,6 +55,14 @@ function CreateMeeting(): JSX.Element {
         meetingId: response.meetingId,
         shareableLink
       }))
+      
+      // Store creator information
+      setCreator({
+        meetingCode: response.meetingCode,
+        facilitatorName: meetingData.facilitatorName,
+        meetingTitle: meetingData.name
+      })
+      
       setStep(2)
 
       // Generate QR in background

--- a/src/pages/FacilitatorView.tsx
+++ b/src/pages/FacilitatorView.tsx
@@ -12,6 +12,7 @@ import { SpeakingDistribution } from '../components/StackKeeper/SpeakingDistribu
 import { InterventionsPanel } from '../components/StackKeeper/InterventionsPanel'
 import useFacilitatorSocket from '../hooks/useFacilitatorSocket'
 import { getQueueTypeDisplay, getQueueTypeColor } from '../utils/queue'
+import { useMeetingCreator } from '../hooks/useMeetingCreator'
 
 interface MeetingData {
   code: string
@@ -24,6 +25,7 @@ function FacilitatorView(): JSX.Element {
   const { meetingId } = useParams()
   const location = useLocation()
   const navigate = useNavigate()
+  const { clearCreator } = useMeetingCreator()
   const showToast = (payload: { title: string; description?: string }) => {
     toast(payload)
   }
@@ -67,6 +69,7 @@ function FacilitatorView(): JSX.Element {
 
   const leaveMeeting = () => {
     disconnect()
+    clearCreator() // Clear creator info when leaving
     navigate('/')
   }
 


### PR DESCRIPTION
Add a 'Facilitate' button to the navbar for meeting creators to easily access their meeting's facilitator view.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c9f5de8-b2ff-473f-9c02-52365243b533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c9f5de8-b2ff-473f-9c02-52365243b533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

