### PR TITLE
Darken light mode and trim home page

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,81 +1,19 @@
-import { Leaf, Users, Sparkles, ArrowRight, CheckCircle } from 'lucide-react'
-
 export const Hero = () => (
   <div className="text-center mb-8 sm:mb-16 relative px-4">
-    {/* Enhanced Logo Section */}
-    <div className="mb-6 sm:mb-8 inline-block">
-      <div className="relative group">
-        <div className="absolute inset-0 bg-primary/20 blur-3xl organic-blob group-hover:bg-primary/30 transition-all duration-500"></div>
-        <div className="relative liquid-glass p-5 sm:p-7 rounded-3xl sm:rounded-[2rem] inline-flex items-center justify-center gap-4 shadow-elegant group-hover:shadow-glow transition-all duration-500">
-          <div className="flex items-center gap-3 sm:gap-4">
-            <div className="relative group/logo">
-              <div className="absolute inset-0 bg-primary/15 rounded-full blur-md group-hover/logo:bg-primary/25 transition-all duration-300"></div>
-              <img 
-                src="/icc-removebg-preview.png" 
-                alt="ICC Austin primary logo" 
-                className="relative w-8 h-8 sm:w-10 sm:h-10 object-contain drop-shadow-lg group-hover/logo:scale-110 transition-all duration-300 dark:brightness-110"
-              />
-            </div>
-            <div className="flex flex-col items-start">
-              <span className="text-xl sm:text-2xl font-bold gradient-text">ICC Austin</span>
-              <span className="text-xs sm:text-sm text-muted-foreground font-medium">Stack Platform</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div className="space-y-6 sm:space-y-8 max-w-5xl mx-auto">
       {/* Main Headline */}
       <div className="space-y-4">
-        <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold hero-text leading-tight tracking-tight">
-          Organic Stack
-          <br />
-          <span className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-light bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">
-            Facilitation
-          </span>
+        <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-foreground leading-tight">
+          Stack Facilitation
         </h1>
-
-        <div className="flex items-center justify-center gap-2 sm:gap-4">
-          <div className="w-16 sm:w-24 h-1 bg-gradient-to-r from-primary via-accent to-primary rounded-full opacity-60"></div>
-          <div className="flex items-center gap-1 text-primary">
-            <Leaf className="w-4 h-4" />
-            <span className="text-sm font-medium">Natural Growth</span>
-          </div>
-          <div className="w-16 sm:w-24 h-1 bg-gradient-to-r from-primary via-accent to-primary rounded-full opacity-60"></div>
-        </div>
       </div>
 
-      {/* Enhanced Description */}
+      {/* Description */}
       <div className="space-y-4 max-w-3xl mx-auto">
-        <p className="text-base sm:text-lg md:text-xl text-muted-foreground leading-relaxed font-light">
+        <p className="text-base sm:text-lg md:text-xl text-muted-foreground leading-relaxed">
           A tool for facilitating democratic discussions with organized speaking queues 
           and fair turn-taking.
         </p>
-        
-        {/* Key Features */}
-        <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6 text-sm sm:text-base">
-          <div className="flex items-center gap-2 text-primary font-medium">
-            <CheckCircle className="w-4 h-4" />
-            <span>Speaking Queue</span>
-          </div>
-          <div className="flex items-center gap-2 text-accent font-medium">
-            <CheckCircle className="w-4 h-4" />
-            <span>Real-time Sync</span>
-          </div>
-          <div className="flex items-center gap-2 text-primary font-medium">
-            <CheckCircle className="w-4 h-4" />
-            <span>Fair Turn-taking</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Call to Action */}
-      <div className="pt-4">
-        <div className="inline-flex items-center gap-2 text-primary font-semibold group cursor-pointer hover:gap-3 transition-all duration-300">
-          <span>Start Your Journey</span>
-          <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-        </div>
       </div>
     </div>
   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,13 @@
 
 @layer base {
   :root {
-    /* Core Colors */
-    --background: 44 9% 98%;
-    --foreground: 30 25% 15%;
-    --card: 44 9% 100%;
-    --card-foreground: 30 25% 15%;
-    --border: 44 9% 88%;
-    --input: 44 9% 95%;
+    /* Core Colors - Darker light mode */
+    --background: 30 25% 20%;
+    --foreground: 60 9% 95%;
+    --card: 30 25% 25%;
+    --card-foreground: 60 9% 95%;
+    --border: 120 13% 30%;
+    --input: 120 13% 25%;
     --ring: 100 40% 35%;
     
     /* Primary Colors */
@@ -19,9 +19,9 @@
     --primary-hover: 100 40% 40%;
     
     /* Secondary Colors */
-    --secondary: 44 9% 92%;
-    --secondary-foreground: 30 25% 15%;
-    --secondary-hover: 44 9% 88%;
+    --secondary: 120 13% 25%;
+    --secondary-foreground: 60 9% 95%;
+    --secondary-hover: 120 13% 30%;
     
     /* Accent Colors */
     --accent: 120 25% 45%;
@@ -29,8 +29,8 @@
     --accent-hover: 120 25% 50%;
     
     /* Muted Colors */
-    --muted: 44 9% 92%;
-    --muted-foreground: 30 10% 45%;
+    --muted: 120 13% 25%;
+    --muted-foreground: 120 5% 80%;
     
     /* Status Colors */
     --warning: 43 96% 56%;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,39 +1,15 @@
 
 import { Hero } from '@/components/Hero'
 import { ActionCards } from '@/components/ActionCards'
-import { HowItWorks } from '@/components/HowItWorks'
-import { Features } from '@/components/Features'
-import { Testimonials } from '@/components/Testimonials'
-// Removed CallToAction to reduce redundancy with ActionCards and header nav
-
 
 function HomePage() {
   return (
     <main className="min-h-screen relative overflow-hidden" role="main">
-      {/* Organic Background Elements - Mobile Responsive */}
-      <div className="absolute inset-0 -z-10" aria-hidden="true">
-        <div className="absolute top-10 sm:top-20 left-2 sm:left-10 w-32 sm:w-48 md:w-64 h-32 sm:h-48 md:h-64 bg-primary/10 organic-blob"></div>
-        <div className="absolute bottom-10 sm:bottom-20 right-2 sm:right-10 w-40 sm:w-60 md:w-80 h-40 sm:h-60 md:h-80 bg-accent/8 organic-blob organic-blob-delay-2"></div>
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-48 sm:w-72 md:w-96 h-48 sm:h-72 md:h-96 bg-primary/5 organic-blob organic-blob-delay-4"></div>
-      </div>
-
       <div className="container mx-auto px-4 sm:px-6 py-8 sm:py-12 lg:py-16">
         <Hero />
         <section aria-labelledby="action-cards-heading" className="mb-8 sm:mb-12">
           <h2 id="action-cards-heading" className="sr-only">Main Actions</h2>
           <ActionCards />
-        </section>
-        <section aria-labelledby="how-it-works-heading" className="mb-8 sm:mb-12">
-          <h2 id="how-it-works-heading" className="sr-only">How It Works</h2>
-          <HowItWorks />
-        </section>
-        <section aria-labelledby="features-heading" className="mb-8 sm:mb-12">
-          <h2 id="features-heading" className="sr-only">Platform Features</h2>
-          <Features />
-        </section>
-        <section aria-labelledby="testimonials-heading">
-          <h2 id="testimonials-heading" className="sr-only">Community Testimonials</h2>
-          <Testimonials />
         </section>
       </div>
     </main>


### PR DESCRIPTION
Make light mode darker and remove home page fluff to simplify the UI and improve readability.

The light mode color palette has been adjusted to use darker tones for backgrounds, cards, and borders, enhancing visual comfort. The home page has been streamlined by removing non-essential sections (Features, Testimonials, HowItWorks) and decorative elements, resulting in a cleaner, more focused user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-895c2703-3cd3-49e3-a1b1-3949ac3f0fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-895c2703-3cd3-49e3-a1b1-3949ac3f0fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

