### PR TITLE
Manage meeting creator state with localStorage

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { Menu, X, Plus, UserPlus, MessageSquare, QrCode } from 'lucide-react'
+import { Menu, X, Plus, UserPlus, MessageSquare, QrCode, Settings } from 'lucide-react'
 import ThemeToggle from '../ui/ThemeToggle'
 import { useMouseFollow } from '@/hooks/use-mouse-follow'
+import { useMeetingCreator } from '@/hooks/useMeetingCreator'
 
 interface AppLayoutProps {
   children: ReactNode
@@ -10,6 +11,7 @@ interface AppLayoutProps {
 
 function AppLayout({ children }: AppLayoutProps) {
   const location = useLocation()
+  const { creatorData, isCreator } = useMeetingCreator()
   const isActive = (path: string) => {
     if (path === '/') {
       return location.pathname === '/'
@@ -159,6 +161,19 @@ function AppLayout({ children }: AppLayoutProps) {
                 )
               })()}
             </nav>
+            
+            {/* Facilitate Button - Desktop */}
+            {isCreator && creatorData && (
+              <button
+                onClick={() => navigate(`/facilitate/${creatorData.meetingCode}`)}
+                className="hidden md:flex items-center px-4 py-2 bg-accent text-white rounded-lg font-semibold hover:bg-accent-hover transition-colors"
+                title={`Facilitate ${creatorData.meetingTitle}`}
+              >
+                <Settings className="w-4 h-4 mr-2" />
+                Facilitate
+              </button>
+            )}
+            
             <ThemeToggle />
             <button
               className="md:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-zinc-800"
@@ -227,6 +242,20 @@ function AppLayout({ children }: AppLayoutProps) {
                   <QrCode className="w-3 h-3 mr-2" />
                   Join Meeting
                 </Link>
+                
+                {/* Facilitate Button - Mobile */}
+                {isCreator && creatorData && (
+                  <button
+                    onClick={() => {
+                      setMobileMenuOpen(false)
+                      navigate(`/facilitate/${creatorData.meetingCode}`)
+                    }}
+                    className="h-8 flex items-center px-4 rounded-lg text-sm font-medium text-accent hover:bg-accent/10 dark:text-accent dark:hover:bg-accent/20"
+                  >
+                    <Settings className="w-3 h-3 mr-2" />
+                    Facilitate {creatorData.meetingTitle}
+                  </button>
+                )}
               </div>
             </div>
           </nav>

--- a/src/hooks/useFacilitatorSocket.ts
+++ b/src/hooks/useFacilitatorSocket.ts
@@ -32,7 +32,8 @@ type ToastFn = (opts: { type: string; title: string }) => void
 export function useFacilitatorSocket(
   meetingCode?: string,
   facilitatorName?: string,
-  showToast?: ToastFn
+  showToast?: ToastFn,
+  facilitatorToken?: string
 ) {
   const [participants, setParticipants] = useState<Participant[]>([])
   const [speakingQueue, setSpeakingQueue] = useState<QueueEntry[]>([])
@@ -107,7 +108,7 @@ export function useFacilitatorSocket(
           socketService.connect()
         }
         setupSocketListeners()
-        await socketService.joinMeeting(meetingCode, facilitatorName, true)
+        await socketService.joinMeeting(meetingCode, facilitatorName, true, facilitatorToken)
         setIsConnected(true)
       } catch (err) {
         if (err.message && err.message.includes('Only the meeting creator can join as facilitator')) {

--- a/src/hooks/useMeetingCreator.ts
+++ b/src/hooks/useMeetingCreator.ts
@@ -1,0 +1,120 @@
+import { useState, useEffect, useCallback } from 'react'
+import apiService from '../services/api'
+
+interface MeetingCreatorData {
+  meetingCode: string
+  meetingId: string
+  facilitatorName: string
+  meetingTitle: string
+  facilitatorToken: string
+  shareUrl: string
+}
+
+interface UseMeetingCreatorReturn {
+  creatorData: MeetingCreatorData | null
+  isCreator: boolean
+  setCreator: (data: MeetingCreatorData) => void
+  clearCreator: () => void
+  validateFacilitator: (meetingCode: string, facilitatorName: string, facilitatorToken: string) => Promise<boolean>
+  isLoading: boolean
+  error: string | null
+}
+
+const STORAGE_KEY = 'meetingCreator'
+
+export function useMeetingCreator(): UseMeetingCreatorReturn {
+  const [creatorData, setCreatorData] = useState<MeetingCreatorData | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load creator data from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        const parsed = JSON.parse(stored)
+        // Validate that all required fields are present
+        if (parsed.meetingCode && parsed.facilitatorName && parsed.facilitatorToken) {
+          setCreatorData(parsed)
+        } else {
+          // Clear invalid data
+          localStorage.removeItem(STORAGE_KEY)
+        }
+      }
+    } catch (err) {
+      console.error('Error loading meeting creator data:', err)
+      localStorage.removeItem(STORAGE_KEY)
+    }
+  }, [])
+
+  const setCreator = useCallback((data: MeetingCreatorData) => {
+    try {
+      setCreatorData(data)
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+      setError(null)
+    } catch (err) {
+      console.error('Error saving meeting creator data:', err)
+      setError('Failed to save facilitator data')
+    }
+  }, [])
+
+  const clearCreator = useCallback(() => {
+    setCreatorData(null)
+    localStorage.removeItem(STORAGE_KEY)
+    setError(null)
+  }, [])
+
+  const validateFacilitator = useCallback(async (
+    meetingCode: string, 
+    facilitatorName: string, 
+    facilitatorToken: string
+  ): Promise<boolean> => {
+    if (!meetingCode || !facilitatorName || !facilitatorToken) {
+      return false
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`${apiService.baseUrl}/api/meetings/${meetingCode}/validate-facilitator`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          facilitatorName,
+          facilitatorToken
+        })
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        return data.valid === true
+      } else {
+        const errorData = await response.json().catch(() => ({}))
+        console.error('Facilitator validation failed:', errorData.error)
+        setError(errorData.error || 'Failed to validate facilitator')
+        return false
+      }
+    } catch (err) {
+      console.error('Error validating facilitator:', err)
+      setError('Network error during validation')
+      return false
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  return {
+    creatorData,
+    isCreator: creatorData !== null,
+    setCreator,
+    clearCreator,
+    validateFacilitator,
+    isLoading,
+    error
+  }
+}
+
+export default useMeetingCreator

--- a/src/pages/CreateMeeting.tsx
+++ b/src/pages/CreateMeeting.tsx
@@ -7,6 +7,7 @@ import { toast } from '@/hooks/use-toast'
 import { playBeep } from '../utils/sound.js'
 import Confetti from '../components/ui/Confetti.jsx'
 import { AppError, getErrorDisplayInfo } from '../utils/errorHandling'
+import { useMeetingCreator } from '../hooks/useMeetingCreator'
 
 interface MeetingData {
   name: string
@@ -18,6 +19,7 @@ interface MeetingData {
 
 function CreateMeeting(): JSX.Element {
   const navigate = useNavigate()
+  const { setCreator } = useMeetingCreator()
   const notify = (type: 'success' | 'error' | 'info', title: string, description?: string) => {
     toast({ title, description })
   }
@@ -54,6 +56,17 @@ function CreateMeeting(): JSX.Element {
         meetingId: response.meetingId,
         shareableLink
       }))
+      
+      // Store facilitator data for persistent access
+      setCreator({
+        meetingCode: response.meetingCode,
+        meetingId: response.meetingId,
+        facilitatorName: meetingData.facilitatorName,
+        meetingTitle: meetingData.name,
+        facilitatorToken: response.facilitatorToken,
+        shareUrl: shareableLink
+      })
+      
       setStep(2)
 
       // Generate QR in background

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -122,6 +122,73 @@ class ApiService {
   getSocketUrl() {
     return this.baseUrl
   }
+
+  async validateFacilitator(meetingCode, facilitatorName, facilitatorToken) {
+    try {
+      // Validate input
+      if (!meetingCode || typeof meetingCode !== 'string' || meetingCode.length !== 6) {
+        throw new AppError(ErrorCode.INVALID_MEETING_CODE, undefined, 'Meeting code must be 6 characters')
+      }
+      
+      if (!facilitatorName || typeof facilitatorName !== 'string' || facilitatorName.trim().length === 0) {
+        throw new AppError(ErrorCode.INVALID_PARTICIPANT_NAME, undefined, 'Facilitator name is required')
+      }
+      
+      if (!facilitatorToken || typeof facilitatorToken !== 'string' || facilitatorToken.trim().length === 0) {
+        throw new AppError(ErrorCode.MISSING_FACILITATOR_TOKEN, undefined, 'Facilitator token is required')
+      }
+
+      const response = await fetch(`${this.baseUrl}/api/meetings/${meetingCode.toUpperCase()}/validate-facilitator`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          facilitatorName: facilitatorName.trim(),
+          facilitatorToken: facilitatorToken.trim()
+        })
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        
+        switch (response.status) {
+          case 400:
+            throw new AppError(ErrorCode.VALIDATION, undefined, errorData.error || 'Invalid request data')
+          case 403:
+            throw new AppError(ErrorCode.UNAUTHORIZED_FACILITATOR, undefined, errorData.error || 'Invalid facilitator credentials')
+          case 404:
+            throw new AppError(ErrorCode.MEETING_NOT_FOUND, undefined, 'Meeting not found')
+          case 500:
+            throw new AppError(ErrorCode.INTERNAL_SERVER_ERROR, undefined, 'Server error occurred')
+          case 503:
+            throw new AppError(ErrorCode.SERVICE_UNAVAILABLE, undefined, 'Service temporarily unavailable')
+          default:
+            throw new AppError(ErrorCode.SERVER, undefined, `Server error: ${response.status}`)
+        }
+      }
+
+      const data = await response.json()
+      return data.valid === true
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error
+      }
+      
+      // Handle network errors
+      if (error.name === 'TypeError' && error.message.includes('fetch')) {
+        throw new AppError(ErrorCode.CONNECTION_FAILED, error, 'Unable to connect to server')
+      }
+      
+      // Handle timeout errors
+      if (error.name === 'AbortError') {
+        throw new AppError(ErrorCode.NETWORK_TIMEOUT, error, 'Request timed out')
+      }
+      
+      logError(error, 'validateFacilitator')
+      throw new AppError(ErrorCode.UNKNOWN, error, 'Failed to validate facilitator')
+    }
+  }
 }
 
 export default new ApiService()

--- a/src/services/socket.js
+++ b/src/services/socket.js
@@ -115,7 +115,7 @@ class SocketService {
   }
 
   // Meeting operations
-  joinMeeting(meetingCode, participantName, isFacilitator = false) {
+  joinMeeting(meetingCode, participantName, isFacilitator = false, facilitatorToken = null) {
     if (!this.socket) {
       throw new AppError(ErrorCode.CONNECTION_FAILED, undefined, 'Socket not connected')
     }
@@ -174,7 +174,8 @@ class SocketService {
       this.socket.emit('join-meeting', {
         meetingCode: meetingCode.toUpperCase(),
         participantName: participantName.trim(),
-        isFacilitator
+        isFacilitator,
+        facilitatorToken
       })
     })
   }

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -22,6 +22,7 @@ export enum ErrorCode {
   INVALID_PARTICIPANT_NAME = 'INVALID_PARTICIPANT_NAME',
   INVALID_QUEUE_TYPE = 'INVALID_QUEUE_TYPE',
   MISSING_REQUIRED_FIELD = 'MISSING_REQUIRED_FIELD',
+  MISSING_FACILITATOR_TOKEN = 'MISSING_FACILITATOR_TOKEN',
   
   // Authentication/Authorization errors
   UNAUTHORIZED_FACILITATOR = 'UNAUTHORIZED_FACILITATOR',
@@ -95,6 +96,11 @@ export const ERROR_MESSAGES: Record<ErrorCode, { title: string; description: str
     title: 'Missing Information',
     description: 'Please fill in all required fields.',
     action: 'Complete all required fields and try again.'
+  },
+  MISSING_FACILITATOR_TOKEN: {
+    title: 'Missing Facilitator Token',
+    description: 'Facilitator token is required to join as facilitator.',
+    action: 'Contact the meeting creator for facilitator access.'
   },
   
   // Authentication/Authorization errors


### PR DESCRIPTION
Implement `useMeetingCreator` with `localStorage` to persist meeting creator status and provide a "Facilitate" button.

This change addresses the issue where facilitators would lose their facilitation view upon page refresh or navigation away from the meeting. By storing creator information in `localStorage`, the system can identify the creator and offer a persistent "Facilitate" button in the navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ae4a634-a191-499d-9d38-3e5b1c570927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ae4a634-a191-499d-9d38-3e5b1c570927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

