### PR TITLE
Add local meeting speaking distribution chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,50 @@
 # Changelog
 
+## 2025-01-27 - Speaking Distribution for Local Meetings
+
+### Summary
+
+Added speaking distribution analytics feature for local meetings, providing pie chart visualization of speaking time distribution among participants. This feature was previously only available for remote meetings and is now available for both local and remote meeting types.
+
+### Key Features
+
+- **Speaking Distribution Charts**: Interactive pie charts showing speaking time distribution
+- **Local Meeting Support**: Full speaking time tracking for manual/local meetings
+- **Real-time Updates**: Charts update automatically as participants speak
+- **Watch View Integration**: Speaking distribution visible in local meeting watch views
+- **Timer Integration**: Automatic speaking time tracking with pause/resume functionality
+- **Direct Response Tracking**: Option to include or exclude direct responses in analytics
+
+### Technical Changes
+
+- **Enhanced useUnifiedFacilitator**: Added speaking history and timer functionality for local meetings
+- **Updated useLocalWatch**: Added speaking distribution data to local meeting watch views
+- **Enhanced WatchView**: Added speaking distribution chart display for local meetings
+- **Updated UnifiedFacilitator**: Speaking distribution now shows for both local and remote meetings
+- **Speaking Time Tracking**: Automatic tracking of speaking segments with proper timer management
+
+### Documentation Updates
+
+- **New Speaking Distribution Guide**: Comprehensive guide for using speaking analytics
+- **Updated Facilitation Guide**: Added section on using speaking distribution for facilitation
+- **Updated Three Meeting Views**: Added speaking distribution to watch view features
+- **Updated README**: Added speaking distribution features to core functionality
+
+### Impact
+
+- **Improved Facilitation**: Facilitators can now monitor participation balance in local meetings
+- **Enhanced Analytics**: Consistent speaking analytics across all meeting types
+- **Better Watch Experience**: Observers can see participation patterns in local meetings
+- **Inclusive Meetings**: Data helps ensure balanced participation and inclusive discussions
+
 ## 2025-08-22 - Frontend Consolidation
 
 ### Summary
+
 This update consolidates the previously separate `frontend` application into the main `src` directory of the `stack-master-tool` repository. This streamlines the codebase by removing redundancy and improving overall organization. The `simple-backend` remains a separate entity but is now integrated with the consolidated frontend.
 
 ### Key Changes
+
 - **Frontend Integration**: The `frontend` directory's contents (specifically `src`) have been moved into `src/frontend` within the main repository.
 - **Dependency Management**: Dependencies from the old `frontend/package.json` have been merged into the root `package.json`.
 - **Configuration Updates**: `vite.config.ts` and `tsconfig.json` have been updated to reflect the new file structure and ensure proper path resolution.
@@ -13,12 +52,12 @@ This update consolidates the previously separate `frontend` application into the
 - **CSS Fix**: A circular dependency issue in `src/index.css` related to the `.fade-in` utility has been resolved.
 
 ### Impact
+
 - **Streamlined Development**: A single frontend codebase simplifies development, maintenance, and deployment.
 - **Reduced Redundancy**: Eliminates duplicate configurations and dependencies.
 - **Improved Organization**: All frontend-related code is now under a single, logical structure.
 
 ### Future Considerations
+
 - Further refactoring of components and services within `src/frontend` to align with the main application's architecture.
 - Potential migration of `simple-backend` into a monorepo structure if further consolidation is desired.
-
-

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Stack Facilitation App is an open-source application for democratic meeting faci
 
 ## ✨ Recent Features
 
+- ✅ **Speaking Distribution for Local Meetings** - Pie chart showing who has talked the most in local meetings
+- ✅ **Real-time Speaking Analytics** - Track speaking time and generate distribution charts for both local and remote meetings
+- ✅ **Enhanced Watch View** - Local meeting watch views now display speaking distribution data
 - ✅ **Name Editing** - Hosts/facilitators can now change participant names and meeting titles in real-time
 - ✅ **Real-time Updates** - All participants see name changes instantly via WebSocket events
 - ✅ **Editable UI Components** - Inline editing with validation and error handling
@@ -26,11 +29,13 @@ This project uses a hybrid architecture with both Supabase (for data persistence
 ### Three Meeting Views
 
 - **HOST** - Full facilitator controls with both manual and remote meeting management
-- **JOIN** - Participant view with queue interaction capabilities  
+- **JOIN** - Participant view with queue interaction capabilities
 - **WATCH** - Public read-only observer view (no authentication required)
 
 ### Core Functionality
 
+- **Speaking Distribution Analytics** - Pie charts showing speaking time distribution for both local and remote meetings
+- **Real-time Speaking Tracking** - Automatic tracking of speaking time with timer controls
 - **Real-time Name Editing** - Facilitators can edit participant names and meeting titles
 - **Unified Facilitator Interface** - Seamlessly switches between manual and remote modes
 - **Speaking Queue Management** - Real-time queue with position tracking and interventions
@@ -38,6 +43,15 @@ This project uses a hybrid architecture with both Supabase (for data persistence
 - **Role-based Access Control** - Secure facilitator-only editing capabilities
 - **Comprehensive Testing** - Unit, integration, and E2E test coverage
 - **Error Handling** - Robust error boundaries and user feedback
+
+### Speaking Distribution Features
+
+- **Pie Chart Visualization** - Interactive pie chart showing speaking time distribution
+- **Real-time Updates** - Chart updates automatically as participants speak
+- **Local Meeting Support** - Works for both local (manual) and remote meetings
+- **Watch View Integration** - Speaking distribution visible in watch views for local meetings
+- **Direct Response Tracking** - Option to include or exclude direct responses in analytics
+- **Timer Integration** - Automatic speaking time tracking with pause/resume functionality
 
 ### Name Editing Features
 
@@ -58,7 +72,7 @@ This project uses a hybrid architecture with both Supabase (for data persistence
 
 ### Prerequisites
 
-- Node.js 18+ 
+- Node.js 18+
 - npm or yarn
 - Supabase account (for database)
 
@@ -123,6 +137,7 @@ You only need Node.js and npm—[install with nvm](https://github.com/nvm-sh/nvm
 ## Technology Stack
 
 ### Frontend
+
 - **Vite** - Fast build tool and dev server
 - **React 18** - UI framework with hooks and context
 - **TypeScript** - Type-safe JavaScript
@@ -132,23 +147,27 @@ You only need Node.js and npm—[install with nvm](https://github.com/nvm-sh/nvm
 - **Socket.io Client** - Real-time communication
 
 ### Backend
+
 - **Express.js** - Web server framework
 - **Socket.io** - Real-time WebSocket communication
 - **Node.js** - JavaScript runtime
 - **CORS** - Cross-origin resource sharing
 
 ### Database
+
 - **Supabase** - PostgreSQL database with real-time subscriptions
 - **Row Level Security (RLS)** - Database-level access control
 - **PostgreSQL** - Relational database
 
 ### Testing
+
 - **Vitest** - Unit testing framework
 - **Playwright** - End-to-end testing
 - **Testing Library** - React component testing
 - **Jest** - Backend testing
 
 ### Development Tools
+
 - **ESLint** - Code linting
 - **Prettier** - Code formatting
 - **Husky** - Git hooks
@@ -162,12 +181,15 @@ stack-facilitation-app/
 │   ├── components/               # React components
 │   │   ├── MeetingRoom/         # Meeting room views (Host, Join, Watch)
 │   │   ├── StackKeeper/         # Speaking queue management
+│   │   │   └── SpeakingDistribution.tsx # Speaking analytics pie chart
 │   │   ├── Facilitator/         # Facilitator-specific components
 │   │   ├── ui/                  # shadcn/ui components
 │   │   ├── EditableParticipantName.tsx  # Name editing component
 │   │   └── EditableMeetingTitle.tsx     # Title editing component
 │   ├── hooks/                   # Custom React hooks
 │   │   ├── useUnifiedFacilitator.ts     # Main facilitator hook
+│   │   ├── useSpeakingHistory.ts        # Speaking time tracking
+│   │   ├── useSpeakerTimer.ts           # Speaker timer functionality
 │   │   ├── useFacilitatorSocket.ts     # Socket.io integration
 │   │   └── useSupabaseFacilitator.ts   # Supabase integration
 │   ├── services/                # API and socket services
@@ -202,11 +224,13 @@ stack-facilitation-app/
 The application uses Supabase for data persistence:
 
 **Tables:**
+
 - `meetings` - Meeting metadata and codes
-- `participants` - Users who have joined meetings  
+- `participants` - Users who have joined meetings
 - `speaking_queue` - Real-time speaking queue with position tracking
 
 **Features:**
+
 - Row Level Security (RLS) policies
 - Real-time subscriptions
 - Automatic meeting code generation
@@ -214,17 +238,20 @@ The application uses Supabase for data persistence:
 ### Backend Server (Express.js)
 
 The Express.js server handles:
+
 - REST API endpoints for meeting management
 - Socket.io WebSocket connections for real-time updates
 - Name editing functionality via API and socket events
 
 **Key Endpoints:**
+
 - `POST /api/meetings` - Create meeting
 - `GET /api/meetings/:code` - Get meeting info
 - `PATCH /api/meetings/:code/title` - Update meeting title
 - `PATCH /api/meetings/:code/participants/:id/name` - Update participant name
 
 **Socket Events:**
+
 - `update-meeting-title` - Real-time title updates
 - `update-participant-name` - Real-time name updates
 - `meeting-title-updated` - Broadcast title changes
@@ -242,6 +269,7 @@ The Express.js server handles:
 ### User Guides
 
 - **[Facilitation Guide](docs/FACILITATION_GUIDE.md)** - How to facilitate meetings
+- **[Speaking Distribution Guide](docs/SPEAKING_DISTRIBUTION.md)** - Using speaking analytics and distribution charts
 - **[Moderation Guide](docs/MODERATION_GUIDE.md)** - Meeting moderation best practices
 
 ### Technical Documentation
@@ -265,6 +293,7 @@ The frontend is deployed via Lovable:
 The backend server is deployed on Render:
 
 **Configuration:**
+
 - **Service name:** `stack-app-backend`
 - **Region:** Oregon (US West)
 - **Instance type:** Free (0.1 CPU, 512 MB)
@@ -278,6 +307,7 @@ The backend server is deployed on Render:
 ### Environment Variables
 
 **Frontend (.env.local):**
+
 ```env
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
@@ -285,6 +315,7 @@ VITE_API_URL=your_backend_url
 ```
 
 **Backend (.env):**
+
 ```env
 SUPABASE_URL=your_supabase_url
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
@@ -325,7 +356,7 @@ PATCH /api/meetings/:code/title
   "facilitatorName": "Facilitator Name"
 }
 
-# Update participant name  
+# Update participant name
 PATCH /api/meetings/:code/participants/:participantId/name
 {
   "newName": "Updated Name",
@@ -337,12 +368,19 @@ PATCH /api/meetings/:code/participants/:participantId/name
 
 ```javascript
 // Emit events
-socket.emit('update-meeting-title', { newTitle: 'New Title' });
-socket.emit('update-participant-name', { participantId: 'id', newName: 'New Name' });
+socket.emit("update-meeting-title", { newTitle: "New Title" });
+socket.emit("update-participant-name", {
+  participantId: "id",
+  newName: "New Name",
+});
 
 // Listen for updates
-socket.on('meeting-title-updated', (data) => { /* handle update */ });
-socket.on('participant-name-updated', (data) => { /* handle update */ });
+socket.on("meeting-title-updated", data => {
+  /* handle update */
+});
+socket.on("participant-name-updated", data => {
+  /* handle update */
+});
 ```
 
 ## Contributing

--- a/docs/FACILITATION_GUIDE.md
+++ b/docs/FACILITATION_GUIDE.md
@@ -43,6 +43,7 @@ Stack facilitation is a democratic meeting process that ensures all voices are h
 ### When to Use Stack Facilitation
 
 Stack facilitation works well for:
+
 - **Large Group Discussions** (10+ people)
 - **Contentious Topics** where emotions may run high
 - **Decision-Making Meetings** requiring input from all stakeholders
@@ -118,6 +119,7 @@ Stack facilitation works well for:
    - **Time Limits**: Set speaking time per person (typically 2-3 minutes)
    - **Queue Limits**: Maximum number of people in queue at once
    - **Direct Response Settings**: Time window and limits for responses
+   - **Speaking Analytics**: Enable speaking time tracking and distribution charts
 
 4. **Privacy and Safety Settings**:
    - **Allow Anonymous Participants**: Decide if people can join without identifying themselves
@@ -192,45 +194,94 @@ Stack facilitation works well for:
 ### Example Facilitator Phrases
 
 **Starting Discussion**:
+
 - "Let's open this topic for discussion. Who would like to share their thoughts?"
 - "I see several hands up. Let me add you to the speaking queue."
 - "We have about 20 minutes for this topic. Please keep comments to 2-3 minutes."
 
 **Managing the Queue**:
+
 - "Sarah, you're next in the queue, followed by Marcus and then Jennifer."
 - "I see you have a direct response, Tom. You'll go next after the current speaker."
 
 **Keeping Discussion Focused**:
+
 - "That's an interesting point. How does it relate to the current proposal?"
 - "I want to make sure we hear from everyone in the queue before moving on."
 - "Let's try to focus on solutions rather than restating the problem."
 
 **Encouraging Participation**:
+
 - "We haven't heard from some folks yet. Anyone else want to share?"
 - "I notice the queue is mostly people who've already spoken. New voices?"
 - "Remember, you can also use the chat for shorter comments or questions."
+
+## Using Speaking Distribution Analytics
+
+### Understanding Speaking Distribution
+
+The Stack Facilitation App now includes speaking distribution analytics that show how speaking time is distributed among participants. This feature helps facilitators ensure balanced participation and identify patterns in who is speaking.
+
+### Features of Speaking Distribution
+
+**Pie Chart Visualization**: An interactive pie chart shows the percentage of speaking time for each participant.
+
+**Real-time Updates**: The chart updates automatically as participants speak and finish their turns.
+
+**Local Meeting Support**: Works for both local (manual) and remote meetings, providing consistent analytics across meeting types.
+
+**Watch View Integration**: Local meeting watch views display speaking distribution data, allowing observers to see participation patterns.
+
+**Direct Response Tracking**: Option to include or exclude direct responses in the analytics to get different perspectives on participation.
+
+### Using Speaking Distribution for Facilitation
+
+**Monitor Participation Balance**: Watch for patterns where certain participants dominate or others are quiet.
+
+**Identify Speaking Patterns**: Notice if some people consistently speak longer or more frequently than others.
+
+**Encourage Balanced Participation**: Use the data to gently encourage quieter participants or ask dominant speakers to step back.
+
+**Share with the Group**: Consider showing the distribution chart to the group to raise awareness about participation patterns.
+
+**Track Progress Over Time**: Use the analytics to see if facilitation efforts are improving participation balance.
+
+### Best Practices for Speaking Analytics
+
+**Use as a Tool, Not a Rule**: The data should inform your facilitation, not dictate it rigidly.
+
+**Consider Context**: Some people may need to speak more due to their role or expertise on a topic.
+
+**Respect Individual Differences**: Some people communicate more through listening than speaking.
+
+**Focus on Inclusion**: Use the data to ensure everyone has opportunities to participate, not to enforce equal time.
+
+**Maintain Privacy**: Be thoughtful about when and how to share participation data with the group.
 
 ## Managing the Speaking Queue
 
 ### Understanding Queue Types
 
 **Raise Hand**: General comments, questions, or new points
+
 - Most common type of queue entry
 - Follows standard FIFO (first in, first out) order
 - Subject to progressive stack prioritization if enabled
 
 **Direct Response**: Immediate response to current speaker
+
 - Time-limited (usually 30-60 seconds)
 - Goes to front of queue
 - Limited number per person to prevent dominance
 
-
 **Point of Information**: Factual information relevant to discussion
+
 - High priority, goes near front of queue
 - Should be objective facts, not opinions
 - Helps inform the discussion with missing information
 
 **Point of Clarification**: Request for speaker to clarify their statement
+
 - Moderate priority
 - Used when something wasn't clear or audible
 - Should be specific about what needs clarification
@@ -249,22 +300,26 @@ Stack facilitation works well for:
 
 ### Dealing with Queue Issues
 
-**Long Queue**: 
+**Long Queue**:
+
 - Pause adding new speakers
 - Ask for brief comments only
 - Consider breaking into small groups
 
 **Empty Queue**:
+
 - Ask specific questions to generate discussion
 - Call on quiet participants directly (with permission)
 - Move to next agenda item if discussion is complete
 
 **Inappropriate Queue Use**:
+
 - Gently correct misuse of direct response or points
 - Remind people of the purpose of different queue types
 - Move items to appropriate queue position if needed
 
 **Technical Problems**:
+
 - Help people join the queue manually if needed
 - Use backup methods (chat, verbal) if the app fails
 - Keep a written backup of the speaking order
@@ -326,15 +381,19 @@ Within each tier, the order is first-come, first-served (FIFO).
 ### Common Concerns and Responses
 
 **"This isn't fair - it should be first come, first served"**
+
 - Response: "Progressive stack helps balance out advantages that some people have in speaking up. The goal is to make sure everyone gets heard, not just the people who are quickest to raise their hands."
 
 **"I don't want to identify myself with tags"**
+
 - Response: "That's completely fine. The tags are voluntary, and you can participate without using any. The system will still work fairly."
 
 **"How do we know people are being honest about their identities?"**
+
 - Response: "We trust people to self-identify honestly. The system is based on good faith participation, just like the rest of our meeting process."
 
 **"This feels divisive or like it's creating categories"**
+
 - Response: "The categories already exist in society - we're just acknowledging them to make sure everyone gets heard. The goal is inclusion, not division."
 
 ### Best Practices for Progressive Stack
@@ -448,18 +507,22 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 ### Example Facilitation Language for Proposals
 
 **Introducing a Proposal**:
+
 - "We have a proposal from Maria about changing our meeting schedule. Maria, would you like to present it?"
 - "Let's take some time to discuss this proposal. I'll open the speaking queue for questions and comments."
 
 **Checking for Consent**:
+
 - "Let's see where everyone stands on this proposal. Please indicate your consent level in the app."
 - "I see we have mostly agrees and stand-asides, but Jennifer has indicated a concern. Jennifer, can you share what's worrying you?"
 
 **Working with Concerns**:
+
 - "Thank you for sharing that concern. Does anyone have ideas for how we might address it?"
 - "Maria, as the proposer, how do you feel about modifying the proposal to address Jennifer's concern?"
 
 **Handling Blocks**:
+
 - "David has indicated a block. David, can you help us understand your objection?"
 - "This seems like a fundamental disagreement about our values. Should we table this proposal and have a broader discussion about our principles?"
 
@@ -484,6 +547,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 **Symptoms**: Interrupting others, making personal attacks, going off-topic repeatedly, dominating discussion.
 
 **Strategies**:
+
 - **Address Privately First**: Use private chat or breakout to speak with them directly
 - **Restate Norms**: Remind the group of agreed-upon meeting guidelines
 - **Use Structure**: Enforce speaking queue and time limits more strictly
@@ -491,6 +555,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 - **Remove if Necessary**: As a last resort, use the app's removal features
 
 **Example Language**:
+
 - "Let's remember our agreement to let each person finish their thoughts before responding."
 - "I need to interrupt here. We agreed to keep comments to 3 minutes, and we need to move to the next speaker."
 - "I'm going to ask everyone to take a deep breath and remember our community guidelines."
@@ -500,6 +565,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 **Symptoms**: Crying, anger, personal attacks, shutting down.
 
 **Strategies**:
+
 - **Stay Calm**: Model the behavior you want to see
 - **Acknowledge Feelings**: "I can see this is really important to you"
 - **Offer Support**: "Would you like to take a short break?"
@@ -507,6 +573,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 - **Follow Up Privately**: Check in with the person after the meeting
 
 **Example Language**:
+
 - "I can see there are strong feelings about this topic. Let's take a moment to breathe."
 - "Thank you for sharing how this affects you. Let's make sure we hear from others too."
 - "Would it be helpful to take a 5-minute break?"
@@ -516,6 +583,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 **Symptoms**: App crashes, internet problems, audio issues.
 
 **Strategies**:
+
 - **Have Backup Plans**: Keep a written list of speakers, use phone conference
 - **Stay Flexible**: Be willing to adapt the process to work with available technology
 - **Help Participants**: Assist people with technical problems
@@ -527,6 +595,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 **Symptoms**: Empty speaking queue, minimal responses, people seeming disengaged.
 
 **Strategies**:
+
 - **Change Format**: Try small group discussions or written input
 - **Ask Direct Questions**: "What questions do people have about this?"
 - **Check Energy**: "How is everyone feeling about this discussion?"
@@ -538,6 +607,7 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 **Symptoms**: People presenting different "facts," confusion about what's true.
 
 **Strategies**:
+
 - **Acknowledge Uncertainty**: "It sounds like we have different information about this"
 - **Assign Research**: "Can someone look into this and report back?"
 - **Focus on Values**: "What principles should guide our decision even if we don't have all the facts?"
@@ -551,7 +621,8 @@ The Stack Facilitation App uses consent-based decision making, which is differen
 
 **How it Works**: Participants can report incidents anonymously through the app.
 
-**Facilitator Response**: 
+**Facilitator Response**:
+
 - Take all reports seriously
 - Follow up privately with involved parties
 - Consider whether immediate action is needed
@@ -624,6 +695,7 @@ Sometimes the most responsible thing is to end a meeting before completing the a
 **Time Constraints**: If it's clear you won't accomplish your goals in the available time.
 
 **How to End Early**:
+
 1. Acknowledge what's happening
 2. Explain why you're ending the meeting
 3. Schedule follow-up if needed
@@ -639,6 +711,7 @@ Sometimes the most responsible thing is to end a meeting before completing the a
 **Generate Meeting Minutes**: Use the app's export function to create a comprehensive record.
 
 **Include Key Information**:
+
 - Decisions made and consent levels
 - Action items and responsible parties
 - Major discussion points and concerns
@@ -735,24 +808,28 @@ Sometimes the most responsible thing is to end a meeting before completing the a
 Consider asking participants these questions to improve future meetings:
 
 **Process Questions**:
+
 - How well did the speaking queue work for you?
 - Did you feel like you had adequate opportunity to participate?
 - Was the progressive stack (if used) helpful or problematic?
 - How was the pace of the meeting?
 
 **Content Questions**:
+
 - Did we accomplish our stated goals?
 - Were the decisions we made good ones?
 - What important topics did we miss?
 - How well did we handle disagreements?
 
 **Inclusion Questions**:
+
 - Did you feel safe and welcome in the meeting?
 - Were all voices heard and respected?
 - How could we be more inclusive in future meetings?
 - Did the technology help or hinder participation?
 
 **Overall Questions**:
+
 - What worked best about this meeting?
 - What was most frustrating or challenging?
 - What would you change about how we run meetings?
@@ -861,4 +938,3 @@ Consider asking participants these questions to improve future meetings:
 This guide is a living document that should be updated based on experience and feedback. The most important thing to remember is that facilitation is both an art and a skill that improves with practice. Be patient with yourself and your group as you learn to use these tools effectively.
 
 **Remember**: The goal is not perfect meetings, but meetings that serve your community's needs for democratic participation and collective decision-making.
-

--- a/docs/SPEAKING_DISTRIBUTION.md
+++ b/docs/SPEAKING_DISTRIBUTION.md
@@ -1,0 +1,197 @@
+# Speaking Distribution Analytics
+
+This document describes the speaking distribution analytics feature that tracks and visualizes speaking time in meetings.
+
+## Overview
+
+The speaking distribution feature provides real-time analytics showing how speaking time is distributed among meeting participants. This helps facilitators ensure balanced participation and identify patterns in who is speaking.
+
+## Features
+
+### Pie Chart Visualization
+
+- **Interactive Chart**: Click on segments to see detailed information
+- **Color-coded Segments**: Each participant gets a unique color
+- **Percentage Display**: Shows both time and percentage for each participant
+- **Real-time Updates**: Chart updates automatically as participants speak
+
+### Speaking Time Tracking
+
+- **Automatic Tracking**: Speaking time is tracked automatically when participants are called to speak
+- **Timer Integration**: Works with the built-in speaker timer system
+- **Pause/Resume Support**: Timer can be paused and resumed, with speaking time calculated accordingly
+- **Accurate Timing**: Tracks actual speaking time, not just time in the speaking position
+
+### Meeting Type Support
+
+- **Local Meetings**: Full support for manual/local meetings with real-time tracking
+- **Remote Meetings**: Works with remote meetings using the same analytics system
+- **Watch Views**: Local meeting watch views display speaking distribution data
+- **Consistent Interface**: Same analytics interface across all meeting types
+
+### Direct Response Handling
+
+- **Include/Exclude Toggle**: Option to include or exclude direct responses in analytics
+- **Separate Tracking**: Direct responses can be tracked separately from regular speaking time
+- **Flexible Analysis**: Allows different perspectives on participation patterns
+
+## How It Works
+
+### Data Collection
+
+1. **Speaker Timer**: When a participant is called to speak, a timer starts automatically
+2. **Time Tracking**: The system tracks how long each person speaks
+3. **Segment Recording**: When a speaker finishes, their speaking time is recorded
+4. **Real-time Updates**: The distribution chart updates immediately
+
+### Data Processing
+
+1. **Aggregation**: Speaking time is aggregated by participant
+2. **Calculation**: Percentages are calculated based on total speaking time
+3. **Sorting**: Participants are sorted by speaking time (highest first)
+4. **Formatting**: Time is displayed in seconds for the chart
+
+### Visualization
+
+1. **Chart Generation**: A pie chart is generated with participant data
+2. **Color Assignment**: Each participant gets a unique color from a predefined palette
+3. **Interactive Elements**: Tooltips and legends provide additional information
+4. **Responsive Design**: Chart adapts to different screen sizes
+
+## User Interface
+
+### Chart Display
+
+- **Expandable Card**: Chart is contained in an expandable card component
+- **Title and Description**: Clear labeling of the analytics feature
+- **Toggle Button**: Button to include/exclude direct responses
+- **Responsive Layout**: Works on desktop and mobile devices
+
+### Chart Controls
+
+- **Include Direct Responses**: Toggle to include or exclude direct response time
+- **Real-time Updates**: Chart updates automatically without manual refresh
+- **Interactive Legend**: Click legend items to highlight chart segments
+- **Tooltip Information**: Hover over segments for detailed information
+
+## Technical Implementation
+
+### Frontend Components
+
+- **SpeakingDistribution.tsx**: Main chart component
+- **Chart Integration**: Uses Recharts library for visualization
+- **Responsive Design**: Tailwind CSS for styling and responsiveness
+
+### Data Management
+
+- **useSpeakingHistory Hook**: Manages speaking time data
+- **useSpeakerTimer Hook**: Handles timer functionality
+- **useUnifiedFacilitator Hook**: Integrates analytics with meeting management
+
+### State Management
+
+- **Speaking Segments**: Array of speaking time records
+- **Real-time Updates**: State updates trigger chart re-renders
+- **Persistent Data**: Speaking history persists during the meeting
+
+## Use Cases
+
+### Facilitation
+
+- **Monitor Participation**: Track who is speaking and for how long
+- **Identify Patterns**: Notice if certain participants dominate or are quiet
+- **Encourage Balance**: Use data to encourage more balanced participation
+- **Share Insights**: Show the group participation patterns
+
+### Meeting Analysis
+
+- **Post-meeting Review**: Analyze participation patterns after meetings
+- **Process Improvement**: Use data to improve meeting facilitation
+- **Participation Trends**: Track changes in participation over time
+- **Meeting Effectiveness**: Assess if meetings are achieving balanced participation
+
+### Training and Development
+
+- **Facilitator Training**: Use analytics to train new facilitators
+- **Best Practices**: Develop guidelines based on participation data
+- **Process Refinement**: Improve meeting processes using data insights
+
+## Best Practices
+
+### For Facilitators
+
+- **Use as a Tool**: Analytics should inform facilitation, not dictate it
+- **Consider Context**: Some people may need to speak more due to their role
+- **Respect Differences**: People communicate differently - some through listening
+- **Focus on Inclusion**: Use data to ensure everyone has opportunities to participate
+
+### For Participants
+
+- **Awareness**: Being aware of participation patterns can help improve meetings
+- **Self-reflection**: Use data to reflect on your own participation
+- **Support Others**: Help create space for quieter voices to be heard
+- **Balance**: Strive for balanced participation while respecting individual differences
+
+### For Organizations
+
+- **Process Improvement**: Use analytics to improve meeting processes
+- **Training**: Include participation awareness in facilitator training
+- **Culture Building**: Foster a culture of balanced participation
+- **Continuous Improvement**: Regularly review and improve meeting practices
+
+## Privacy and Ethics
+
+### Data Handling
+
+- **Meeting Scope**: Speaking data is only collected during active meetings
+- **No Persistent Storage**: Data is not stored permanently after meetings
+- **Consent**: Participants are aware that speaking time is being tracked
+- **Transparency**: The feature is clearly visible and explained to participants
+
+### Ethical Considerations
+
+- **Inclusion Focus**: Use data to promote inclusion, not to enforce rigid rules
+- **Respect Privacy**: Be thoughtful about when and how to share participation data
+- **Avoid Shaming**: Never use data to shame or embarrass participants
+- **Supportive Environment**: Create an environment where everyone feels comfortable participating
+
+## Troubleshooting
+
+### Common Issues
+
+**Chart Not Updating**: Check if the speaker timer is running and participants are being tracked properly.
+
+**Missing Data**: Ensure that speaking segments are being recorded when participants finish speaking.
+
+**Display Issues**: Verify that the chart component is properly mounted and receiving data.
+
+**Timer Problems**: Check that the speaker timer is working correctly and recording time accurately.
+
+### Technical Support
+
+- **Browser Compatibility**: Ensure you're using a supported browser
+- **JavaScript Enabled**: Make sure JavaScript is enabled in your browser
+- **Network Connection**: Verify that you have a stable internet connection
+- **App Updates**: Ensure you're using the latest version of the app
+
+## Future Enhancements
+
+### Planned Features
+
+- **Export Functionality**: Export speaking distribution data for analysis
+- **Historical Data**: Track participation patterns across multiple meetings
+- **Advanced Analytics**: More detailed analytics and reporting features
+- **Custom Visualizations**: Different chart types and visualization options
+
+### Potential Improvements
+
+- **Participation Goals**: Set and track participation goals for meetings
+- **Automated Insights**: AI-powered insights about participation patterns
+- **Integration**: Better integration with other meeting management tools
+- **Mobile Optimization**: Enhanced mobile experience for analytics
+
+## Conclusion
+
+The speaking distribution analytics feature provides valuable insights into meeting participation patterns, helping facilitators create more inclusive and effective meetings. By tracking speaking time and visualizing participation data, the feature supports democratic meeting processes and helps ensure all voices are heard.
+
+The feature is designed to be transparent, respectful, and focused on inclusion, providing tools for facilitators to improve meeting quality while maintaining participant privacy and comfort.

--- a/docs/three-meeting-views.md
+++ b/docs/three-meeting-views.md
@@ -155,9 +155,10 @@ const MeetingRoomWithModes = () => {
 - Participant list with controls
 - Current speaker management
 - Meeting settings and controls
-- Speaking distribution analytics
+- Speaking distribution analytics (local and remote meetings)
 - Interventions tracking
 - Real-time participant updates
+- Speaking time tracking with timer controls
 
 #### JOIN View Features ✅
 
@@ -175,6 +176,7 @@ const MeetingRoomWithModes = () => {
 - Current speaker indicator
 - Participant list (names only)
 - Meeting information display
+- Speaking distribution analytics (for local meetings)
 - "Join Meeting" call-to-action
 - Real-time updates (when available)
 - Public access (no authentication)


### PR DESCRIPTION
Add speaking distribution pie chart and tracking for local meetings to enable facilitators to monitor participant speaking time.

---
<a href="https://cursor.com/background-agent?bcId=bc-b88f3dd8-f910-4eef-b29e-b7226ac84237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b88f3dd8-f910-4eef-b29e-b7226ac84237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

